### PR TITLE
Make jsreport-jsrender depend on jsrender, rather than node-jsrender

### DIFF
--- a/lib/jsrenderEngine.js
+++ b/lib/jsrenderEngine.js
@@ -2,50 +2,19 @@
  * Copyright(c) 2014 Jan Blaha
  */
 
-var regex = /<script[^>]*id=["'](.*?)["'].*type=["']text\/x-jsrender['"][\s\S.^>]*?>([\s\S]*?)<\/script>/gi;
-var jsrender = require('node-jsrender');
-
-function trim (str) {
-  return str.replace(/^\s\s*/, '').replace(/\s\s*$/, '');
-}
+var regex = /<script[^>]*id=["'](.*?)["'].*type=["']text\/x-jsrender['"][^>]*?>([\s\S]*?)<\/script>/gi;
+var jsrender = require('jsrender');
 
 module.exports = function (html, helpers, data) {
   //load <script id="columnTemplate" type="text/x-jsrender"> ... </script> jsrender child templates
-  var templates = [];
-  var matches = html.match(new RegExp(regex));
+  var subtemplates = {};
+  html = html.replace(regex, function(subtemplate, name, markup) {
+    subtemplates[name] = markup;  // Add subtemplate markup to subtemplates hash
+    return "";                    // Remove nested subtemplate declarations from html
+  });
 
-  var error = null;
-  try {
-    jsrender.jsviews.views.settings.onError = function(e) {
-      error = e;
-    };
-
-    for (var i in matches) {
-      var parts = new RegExp(regex).exec(matches[i]);
-      templates.push(parts[1]);
-      jsrender.loadString(parts[1], trim(parts[2]));
-      html = html.replace(parts[0], "");
-    }
-
-    jsrender.loadString('template', html || " ");
-
-    var result = jsrender.render.template(data || {}, helpers);
-    if (error)
-      throw error;
-    return result;
-  }
-  catch(e) {
-    if (error)
-      throw error;
-
-    throw e;
-  }
-  finally {
-    //templates are registered globally, we need to remove them afterwards so other requests don't see them
-    //actually I don't know how to physically remove them, so I just assign template name to its content and
-    //that has same affect as removing.
-    for (var id in templates) {
-      jsrender.loadString(templates[id], templates[id]);
-    }
-  }
+  var tmpl = jsrender.templates(html || " ");     // Compile main template
+  jsrender.templates(subtemplates, tmpl);         // Compile named subtemplates, scoped to main template
+  var result = tmpl.render(data || {}, helpers);  // Render to string
+  return result;
 };

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "license": "LGPL",
   "dependencies": {
     "mocha": "^2.3.4",
-    "node-jsrender": "1.0.6",
+    "jsrender": "^0.9.74",
     "should": "^8.1.1"
   },
   "author": "Jan Blaha",

--- a/test/jsrenderTest.js
+++ b/test/jsrenderTest.js
@@ -30,6 +30,12 @@ describe('jsrender', function(){
     }).throw();
   });
 
+  it('should throw when use constr expression', function () {
+    should(function() {
+      jsrender('{{:#tmpl.constructor("var foo=3;")()}}', null, {});
+    }).throw();
+  });
+
   it('should be able to parse and use sub tempates', function () {
     var childTemplate = "<script id=\"inner\" type=\"text/x-jsrender\">{{:#data}}</script>";
     var template = "{{for items tmpl=\"inner\"}}{{/for}}";


### PR DESCRIPTION
Hi Jan,

Here is my proposed update. 

JsRender now provides complete nodejs integration, and includes latest features, security fix, etc. - and node-jsrender is no longer maintained, so best to depend directly on jsrender.

I simplified jsrenderEngine.js, using appropriate JsRender features, and added a test case for the fix discussed by email.

Boris
